### PR TITLE
Fixed 'attemptType' variable never being reset after successful attempts

### DIFF
--- a/RMYouTubeExtractor/RMYouTubeExtractor.m
+++ b/RMYouTubeExtractor/RMYouTubeExtractor.m
@@ -143,6 +143,7 @@ static NSString *ApplicationLanguageIdentifier(void)
                        if (!contentIsAvailable) {
                            [self extractVideoForIdentifier:videoIdentifier completion:completion];
                        } else {
+                           self.attemptType = RMYouTubeExtractorAttemptTypeEmbedded;
                            dispatch_async(dispatch_get_main_queue(), ^{
                                completion(videoDictionary, nil);
                            });


### PR DESCRIPTION
Being used as a singleton, the state of the extractor is preserved through distinct usages. By incrementing the value of `self.attemptType` after an extraction attempt, we're able to try another attempt using another type if it fails. But if it succeeds, **the state isn't reset**, so if we try to extract the URL of multiple videos afterwards, we'll eventually start directly on the `RMYouTubeExtractorAttemptTypeError` type and the extractor **will fail without even trying**.

I suggest you simply **reset the `self.attemptType` to `RMYouTubeExtractorAttemptTypeEmbedded`** when the extraction successfully returns, so the next attempts will start in the right state. You may have other ideas on how to fix this, but I thought it would be more convenient to suggest a fix through a *pull request* than simply create an *issue* on the repository.

Thanks for your attention, and I tip my hat to you for creating this pod, it's very useful! :tophat: :blush: